### PR TITLE
Update Swagger configuration

### DIFF
--- a/CovidSafe/CovidSafe.API/Controllers/MessageController.cs
+++ b/CovidSafe/CovidSafe.API/Controllers/MessageController.cs
@@ -55,6 +55,7 @@ namespace CovidSafe.API.Controllers
         /// <response code="200">Successful request with results</response>
         /// <response code="400">Malformed or invalid request provided</response>
         /// <returns>Collection of <see cref="MatchMessage"/> objects matching request parameters</returns>
+        [ApiExplorerSettings(IgnoreApi = true)]
         [HttpPost]
         [Consumes("application/x-protobuf", "application/json")]
         [Produces("application/x-protobuf", "application/json")]

--- a/CovidSafe/CovidSafe.API/Controllers/MessageControllers/AreaReportController.cs
+++ b/CovidSafe/CovidSafe.API/Controllers/MessageControllers/AreaReportController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -56,14 +57,14 @@ namespace CovidSafe.API.Controllers.MessageControllers
         /// </remarks>
         /// <param name="request"><see cref="AreaMatch"/> to be stored</param>
         /// <param name="cancellationToken">Cancellation token (not required in API call)</param>
-        /// <response code="200">Query matched Trace results</response>
-        /// <response code="400">Malformed or invalid query provided</response>
+        /// <response code="200">Submission successful</response>
+        /// <response code="400">Malformed or invalid request</response>
         [HttpPut]
         [Consumes("application/x-protobuf", "application/json")]
         [Produces("application/x-protobuf", "application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
-        public async Task<ActionResult> PutAsync(AreaMatch request, CancellationToken cancellationToken = default)
+        public async Task<ActionResult> PutAsync([Required] AreaMatch request, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/CovidSafe/CovidSafe.API/Controllers/MessageControllers/SeedReportController.cs
+++ b/CovidSafe/CovidSafe.API/Controllers/MessageControllers/SeedReportController.cs
@@ -58,8 +58,8 @@ namespace CovidSafe.API.Controllers.MessageControllers
         /// </remarks>
         /// <param name="request"><see cref="SelfReportRequest"/> content</param>
         /// <param name="cancellationToken">Cancellation token (not required in API call)</param>
-        /// <response code="200">Query matched Trace results</response>
-        /// <response code="400">Malformed or invalid query provided</response>
+        /// <response code="200">Submission successful</response>
+        /// <response code="400">Malformed or invalid request</response>
         [HttpPut]
         [Consumes("application/x-protobuf", "application/json")]
         [Produces("application/x-protobuf", "application/json")]

--- a/CovidSafe/CovidSafe.API/CovidSafe.API.csproj
+++ b/CovidSafe/CovidSafe.API/CovidSafe.API.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.3.1" />
     <PackageReference Include="WebApiContrib.Core.Formatter.Protobuf" Version="2.1.3" />
   </ItemGroup>
 

--- a/CovidSafe/CovidSafe.API/Properties/launchSettings.json
+++ b/CovidSafe/CovidSafe.API/Properties/launchSettings.json
@@ -12,15 +12,15 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger/v1/swagger.json",
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "TraceDefense.API": {
+    "CovidSafe.API": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/values",
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/CovidSafe/CovidSafe.API/Startup.cs
+++ b/CovidSafe/CovidSafe.API/Startup.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using Swashbuckle.AspNetCore.SwaggerUI;
 using WebApiContrib.Core.Formatter.Protobuf;
 
 namespace CovidSafe.API

--- a/CovidSafe/CovidSafe.API/Startup.cs
+++ b/CovidSafe/CovidSafe.API/Startup.cs
@@ -13,12 +13,14 @@ using CovidSafe.DAL.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.SwaggerUI;
 using WebApiContrib.Core.Formatter.Protobuf;
 
 namespace CovidSafe.API
@@ -110,7 +112,7 @@ namespace CovidSafe.API
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApiVersionDescriptionProvider provider)
         {
             if (env.IsDevelopment())
             {
@@ -142,6 +144,19 @@ namespace CovidSafe.API
                     // Set servers (hosts) property
                     swagger.Servers = servers;
                 });
+            });
+
+            // Add SwaggerUI
+            app.UseSwaggerUI(c =>
+            {
+                // Enable UI for multiple API versions
+                foreach(ApiVersionDescription description in provider.ApiVersionDescriptions)
+                {
+                    c.SwaggerEndpoint(
+                        $"/swagger/{description.GroupName}/swagger.json",
+                        description.GroupName.ToUpperInvariant()
+                    );
+                }
             });
         }
     }

--- a/CovidSafe/CovidSafe.API/Swagger/SwaggerConfigureOptions.cs
+++ b/CovidSafe/CovidSafe.API/Swagger/SwaggerConfigureOptions.cs
@@ -15,7 +15,7 @@ namespace CovidSafe.API.Swagger
     /// CodeCoverageExclusion: Does not provide core functionality.
     /// </remarks>
     [ExcludeFromCodeCoverage]
-    public class SwaggerConfiguration : IConfigureOptions<SwaggerGenOptions>
+    public class SwaggerConfigureOptions : IConfigureOptions<SwaggerGenOptions>
     {
         /// <summary>
         /// Configures API version description handling
@@ -23,10 +23,10 @@ namespace CovidSafe.API.Swagger
         readonly IApiVersionDescriptionProvider _provider;
 
         /// <summary>
-        /// Creates a new <see cref="SwaggerConfiguration"/> instance
+        /// Creates a new <see cref="SwaggerConfigureOptions"/> instance
         /// </summary>
         /// <param name="provider">API Version Description provider implementation</param>
-        public SwaggerConfiguration(IApiVersionDescriptionProvider provider) => this._provider = provider;
+        public SwaggerConfigureOptions(IApiVersionDescriptionProvider provider) => this._provider = provider;
 
         /// <inheritdoc/>
         public void Configure(SwaggerGenOptions options)

--- a/CovidSafe/CovidSafe.API/appsettings.json
+++ b/CovidSafe/CovidSafe.API/appsettings.json
@@ -1,17 +1,18 @@
 {
+  "AllowedHosts": "*",
   "ApplicationInsights": {
     "InstrumentationKey": ""
   },
+  "CosmosSchema": {
+    "DatabaseName": "traces",
+    "MaxDataAgeToReturnDays": 14,
+    "MessageContainerName": "messages_test_3"
+  },
+  "KeyVaultUrl": "https://covidsafe-api.vault.azure.net/",
   "Logging": {
     "LogLevel": {
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "CosmosCovidSafeSchema": {
-    "DatabaseName": "traces",
-    "MaxDataAgeToReturnDays": 14,
-    "MessageContainerName": "messages_test_3"
-  },
-  "KeyVaultUrl": "https://covidsafe-api.vault.azure.net/"
+  "SwaggerHosts": "https://localhost:44347/"
 }

--- a/CovidSafe/CovidSafe.DAL/Repositories/Cosmos/Client/CosmosContext.cs
+++ b/CovidSafe/CovidSafe.DAL/Repositories/Cosmos/Client/CosmosContext.cs
@@ -9,12 +9,12 @@ namespace CovidSafe.DAL.Repositories.Cosmos.Client
     public class CosmosContext
     {
         /// <summary>
-        /// <see cref="IOptionsMonitor{T}"/> reference for <see cref="CosmosCovidSafeSchemaOptions"/>
+        /// <see cref="IOptionsMonitor{T}"/> reference for <see cref="CosmosSchemaConfigurationSection"/>
         /// </summary>
         /// <remarks>
         /// Enables configuration change detection without restarting service
         /// </remarks>
-        private IOptionsMonitor<CosmosCovidSafeSchemaOptions> _schemaConfig { get; set; }
+        private IOptionsMonitor<CosmosSchemaConfigurationSection> _schemaConfig { get; set; }
         /// <summary>
         /// <see cref="CosmosClient"/> instance
         /// </summary>
@@ -24,9 +24,9 @@ namespace CovidSafe.DAL.Repositories.Cosmos.Client
         /// </summary>
         public Database Database { get; private set; }
         /// <summary>
-        /// <see cref="CosmosCovidSafeSchemaOptions"/> instance
+        /// <see cref="CosmosSchemaConfigurationSection"/> instance
         /// </summary>
-        public CosmosCovidSafeSchemaOptions SchemaOptions
+        public CosmosSchemaConfigurationSection SchemaOptions
         {
             get
             {
@@ -39,7 +39,7 @@ namespace CovidSafe.DAL.Repositories.Cosmos.Client
         /// </summary>
         /// <param name="connectionFactory">Database connection factory instance</param>
         /// <param name="schemaConfig">Schema configuration provider</param>
-        public CosmosContext(CosmosConnectionFactory connectionFactory, IOptionsMonitor<CosmosCovidSafeSchemaOptions> schemaConfig)
+        public CosmosContext(CosmosConnectionFactory connectionFactory, IOptionsMonitor<CosmosSchemaConfigurationSection> schemaConfig)
         {
             // Set local variables
             this._schemaConfig = schemaConfig;
@@ -51,7 +51,7 @@ namespace CovidSafe.DAL.Repositories.Cosmos.Client
 
         /// <summary>
         /// Gets a reference to the specified <see cref="Container"/> from the 
-        /// local <see cref="CosmosCovidSafeSchemaOptions"/> instance
+        /// local <see cref="CosmosSchemaConfigurationSection"/> instance
         /// </summary>
         /// <param name="containerName">Target <see cref="Container"/> name</param>
         /// <returns><see cref="Container"/> reference</returns>

--- a/CovidSafe/CovidSafe.DAL/Repositories/Cosmos/Client/CosmosSchemaConfigurationSection.cs
+++ b/CovidSafe/CovidSafe.DAL/Repositories/Cosmos/Client/CosmosSchemaConfigurationSection.cs
@@ -6,7 +6,7 @@ namespace CovidSafe.DAL.Repositories.Cosmos.Client
     /// <summary>
     /// Settings object for using Cosmos with the CovidSafe schema
     /// </summary>
-    public class CosmosCovidSafeSchemaOptions
+    public class CosmosSchemaConfigurationSection
     {
         /// <summary>
         /// Cosmos target database name
@@ -22,9 +22,9 @@ namespace CovidSafe.DAL.Repositories.Cosmos.Client
         public string MessageContainerName { get; set; }
 
         /// <summary>
-        /// Creates a new <see cref="CosmosCovidSafeSchemaOptions"/> instance
+        /// Creates a new <see cref="CosmosSchemaConfigurationSection"/> instance
         /// </summary>
-        public CosmosCovidSafeSchemaOptions()
+        public CosmosSchemaConfigurationSection()
         {
         }
     }


### PR DESCRIPTION
* Adds SwaggerUI to replace API Management portal
* Adds `SwaggerHosts` configuration element and honors this on SwaggerDoc generation
  * Must be set properly on production hosts, usually to Front Door URL
* Updates name of `CosmosCovidSafeSchemaConfiguration` to `CosmosSchemaConfigurationSection`
  * Clarifies class purpose and source
* Fixes comments on some endpoints
* Hides HEAD method from API docs for `MessageController`